### PR TITLE
Unbroke horse_drop.json

### DIFF
--- a/src/main/resources/data/callablehorses/loot_modifiers/horse_drop.json
+++ b/src/main/resources/data/callablehorses/loot_modifiers/horse_drop.json
@@ -1,11 +1,8 @@
 {
-  "conditions": [
-    {
-	  "condition": "minecraft:entity_properties",
-	  "predicate": {
-		   "type": "#callablehorses:callablehorses"
-	  },
-	  "entity": "THIS"
-    }
-  ]
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "type": "#callablehorses:callablehorses"
+  }
 }
+


### PR DESCRIPTION
Fixes console errors, but horses will still dupe loot regardless